### PR TITLE
syntax error fixed

### DIFF
--- a/lib/docverter/conversion.rb
+++ b/lib/docverter/conversion.rb
@@ -88,7 +88,7 @@ module Docverter
         :to => to,
         :content => content,
         :input_files => [],
-        :other_files => [],
+        :other_files => []
       )
     end
 


### PR DESCRIPTION
I fixed a syntax error while evaluating docverter-example app on ruby-1.9.2-p318, causing "Boot Error: Something went wrong while loading config.ru".
