### PR TITLE
Update docverter.gemspec

### DIFF
--- a/docverter.gemspec
+++ b/docverter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("rest-client", ["~>1.7"])
+  gem.add_dependency("rest-client", ["~>=1.9"])
   gem.add_development_dependency("mocha")
   gem.add_development_dependency("shoulda")
 end


### PR DESCRIPTION
rest-client-1.8.0 doesn't work with Ruby >= 2.4.2